### PR TITLE
feat(ui/modal): Criação de componentes Modal e Dialog

### DIFF
--- a/src/shared/components/atoms/dialog/index.tsx
+++ b/src/shared/components/atoms/dialog/index.tsx
@@ -1,0 +1,121 @@
+import React from "react"
+
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+
+import { cn } from "@/shared/utils/cn"
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Close>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Close>
+>(({ className, ...props }, ref) => {
+	return (
+		<DialogPrimitive.Close
+			ref={ref}
+			className={cn("text-white focus:shadow-black/80", className)}
+			{...props}
+		/>
+	)
+})
+DialogClose.displayName = DialogPrimitive.Close.displayName
+
+const DialogOverlay = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Overlay>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+	<DialogPrimitive.Overlay
+		ref={ref}
+		className={cn(
+			"fixed inset-0",
+			"bg-black/70",
+			"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+			className
+		)}
+		{...props}
+	/>
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogActions = React.forwardRef<
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+	return (
+		<div
+			ref={ref}
+			className={cn("flex w-full justify-center gap-4 md:justify-end", className)}
+			{...props}
+		/>
+	)
+})
+DialogActions.displayName = "DialogActions"
+
+const DialogContent = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Content>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, ...props }, ref) => {
+	return (
+		<DialogPrimitive.Content
+			ref={ref}
+			className={cn(
+				"fixed left-1/2 top-1/2 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 space-y-4 rounded-md border p-9 focus:outline-none sm:max-w-md lg:max-w-xl",
+				"border-content-shape-quaternary bg-content-shape-primary text-white",
+				className
+			)}
+			{...props}
+		/>
+	)
+})
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
+	<header
+		className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
+		{...props}
+	/>
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLElement>) => (
+	<footer className={cn("flex justify-end gap-2", className)} {...props} />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Title>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+	<DialogPrimitive.Title
+		ref={ref}
+		className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+		{...props}
+	/>
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Description>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+	<DialogPrimitive.Description
+		ref={ref}
+		className={cn("text-sm text-muted-foreground", className)}
+		{...props}
+	/>
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+	Dialog,
+	DialogPortal,
+	DialogOverlay,
+	DialogClose,
+	DialogTrigger,
+	DialogContent,
+	DialogHeader,
+	DialogFooter,
+	DialogTitle,
+	DialogDescription,
+	DialogActions
+}

--- a/src/shared/components/molecules/dialog/index.tsx
+++ b/src/shared/components/molecules/dialog/index.tsx
@@ -1,0 +1,68 @@
+import { forwardRef, type ReactNode } from "react"
+
+import {
+	DialogActions,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogOverlay,
+	DialogPortal,
+	Dialog as DialogRoot,
+	DialogTitle,
+	DialogTrigger
+} from "@/shared/components/atoms/dialog"
+import { Icon } from "@/shared/components/atoms/icon/Icon"
+
+type DialogProps = {
+	title: string
+	description: string
+	trigger: ReactNode
+	layout?: "WithCloseAction" | "WithCustomActions" | undefined
+	customActions?: ReactNode | undefined
+} & React.ComponentPropsWithoutRef<typeof DialogContent>
+
+const Dialog = forwardRef<React.ElementRef<typeof DialogContent>, DialogProps>(
+	(
+		{
+			title,
+			description,
+			trigger,
+			children,
+			layout = "WithCloseAction",
+			customActions,
+			...props
+		},
+		ref
+	) => {
+		return (
+			<DialogRoot modal={false}>
+				<DialogTrigger>{trigger}</DialogTrigger>
+				<DialogPortal>
+					<DialogOverlay />
+					<DialogContent ref={ref} {...props}>
+						<DialogHeader>
+							<DialogTitle>{title}</DialogTitle>
+							<DialogDescription>{description}</DialogDescription>
+						</DialogHeader>
+						{children}
+						<DialogFooter>
+							{layout === "WithCustomActions" && typeof customActions != "undefined" ? (
+								<DialogActions>{customActions}</DialogActions>
+							) : (
+								<DialogClose className="absolute right-2.5 top-2.5 inline-flex size-10 justify-end">
+									<Icon name="X" size="20" />
+									<span className="sr-only">FECHAR</span>
+								</DialogClose>
+							)}
+						</DialogFooter>
+					</DialogContent>
+				</DialogPortal>
+			</DialogRoot>
+		)
+	}
+)
+
+export { Dialog }
+export type { DialogProps }

--- a/src/shared/components/molecules/modal/index.tsx
+++ b/src/shared/components/molecules/modal/index.tsx
@@ -1,0 +1,78 @@
+import { forwardRef, type ReactNode } from "react"
+
+import {
+	DialogActions as ModalActions,
+	DialogClose as ModalClose,
+	DialogContent as ModalContent,
+	DialogDescription as ModalDescription,
+	DialogFooter as ModalFooter,
+	DialogHeader as ModalHeader,
+	DialogOverlay as ModalOverlay,
+	DialogPortal as ModalPortal,
+	Dialog as ModalRoot,
+	DialogTitle as ModalTitle,
+	DialogTrigger as ModalTrigger
+} from "@/shared/components/atoms/dialog"
+import { Icon } from "@/shared/components/atoms/icon/Icon"
+
+type ModalProps = {
+	title: string
+	description: string
+	trigger: ReactNode
+	defaultCloseButton?: boolean
+	layout?: "WithCloseAction" | "WithCustomActions" | undefined
+	customActions?: ReactNode | undefined
+} & React.ComponentPropsWithoutRef<typeof ModalContent>
+
+const Modal = forwardRef<React.ElementRef<typeof ModalContent>, ModalProps>(
+	(
+		{
+			title,
+			description,
+			trigger,
+			children,
+			defaultCloseButton,
+			layout = "WithCloseAction",
+			customActions,
+			...props
+		},
+		ref
+	) => {
+		return (
+			<ModalRoot modal>
+				<ModalTrigger asChild>{trigger}</ModalTrigger>
+				<ModalPortal>
+					<ModalOverlay />
+					<ModalContent ref={ref} {...props}>
+						<ModalHeader>
+							<ModalTitle>{title}</ModalTitle>
+							<ModalDescription>{description}</ModalDescription>
+						</ModalHeader>
+						{children}
+						<ModalFooter>
+							{layout === "WithCustomActions" && typeof customActions != "undefined" ? (
+								<ModalActions className="flex flex-row flex-wrap">
+									{defaultCloseButton && (
+										<ModalClose className="absolute right-2.5 top-2.5 inline-flex size-10 justify-end">
+											<Icon name="X" size="20" />
+											<span className="sr-only">FECHAR</span>
+										</ModalClose>
+									)}
+									{customActions}
+								</ModalActions>
+							) : (
+								<ModalClose>
+									<Icon name="X" size="20" />
+									<span className="sr-only">FECHAR</span>
+								</ModalClose>
+							)}
+						</ModalFooter>
+					</ModalContent>
+				</ModalPortal>
+			</ModalRoot>
+		)
+	}
+)
+
+export { Modal }
+export type { ModalProps }

--- a/src/stories/Dialog.stories.tsx
+++ b/src/stories/Dialog.stories.tsx
@@ -1,0 +1,34 @@
+import { type Meta, type StoryObj } from "@storybook/react"
+
+import { Button } from "@/shared/components/atoms/button"
+import { Dialog } from "@/shared/components/molecules/dialog"
+
+const meta: Meta<typeof Dialog> = {
+	title: "Molecules/Dialog",
+	component: Dialog,
+	parameters: {
+		controls: {
+			exclude: ["trigger", "children", "customActions"]
+		}
+	},
+	argTypes: {},
+	args: {
+		trigger: <Button>Open Dialog</Button>,
+		title: "Lorem ipsum",
+		description: "Lorem ipsum dolor sit amet consectetur adipisicing elit",
+		children: (
+			<p>
+				Numquam quos minus veritatis, aperiam iure facilis exercitationem totam laboriosam
+				excepturi harum sunt aliquam ipsum. Perspiciatis earum alias laboriosam ad est
+				ullam!
+			</p>
+		),
+		layout: "WithCloseAction"
+	}
+}
+
+export default meta
+
+export const Default: StoryObj<typeof Dialog> = {
+	render: (args) => <Dialog {...args} />
+}

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -1,0 +1,61 @@
+import { type Meta, type StoryObj } from "@storybook/react"
+
+import { Button } from "@/shared/components/atoms/button"
+import { Input } from "@/shared/components/atoms/input/input"
+import { Label } from "@/shared/components/atoms/label"
+import { Textarea } from "@/shared/components/atoms/textArea"
+import { Modal } from "@/shared/components/molecules/modal"
+
+const meta: Meta<typeof Modal> = {
+	title: "Molecules/Modal",
+	component: Modal,
+	parameters: {
+		controls: {
+			exclude: ["trigger", "children", "customActions"]
+		}
+	},
+	args: {
+		trigger: <Button>Open Modal</Button>,
+		title: "Molecules/Modal",
+		description: "Modal with Form",
+		layout: "WithCustomActions",
+		customActions: (
+			<>
+				<Button variant={"secondary"} className="w-full md:w-fit">
+					Salvar
+				</Button>
+				<Button variant={"default"} className="w-full md:w-fit">
+					Publicar
+				</Button>
+			</>
+		)
+	}
+}
+
+export default meta
+
+export const Default: StoryObj<typeof meta> = {
+	args: {
+		children: (
+			<form className="space-y-4">
+				<div className="space-y-1.5">
+					<Label htmlFor="articleTitleInput">Title</Label>
+					<Input
+						id="articleTitleInput"
+						type="text"
+						placeholder="Insert the article title"
+					/>
+				</div>
+				<div className="space-y-1.5">
+					<Label htmlFor="articleDescInput">Description</Label>
+					<Textarea
+						id="articleDescInput"
+						className="h-40"
+						placeholder="Insert the body of article"
+					/>
+				</div>
+			</form>
+		)
+	},
+	render: (args) => <Modal {...args} />
+}


### PR DESCRIPTION
### O que foi feito?
- Criados os componentes [`Modal`](452c090fcc08590c647d446c8576498eddd1faf7) e [`Dialog`](4c8f464afe26bd58f4b942b65a869102751dd411) reutilizáveis.

### Como foi implementado?
- Adicionados exemplos no Storybook para testar os novos componentes.
- Foi utilizado os componentes do `Radix-UI` para acessibilidade.