### PR TITLE
Migração do `Head` para a `API de Metadata` do Next.js

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,13 @@
 import type { Metadata } from "next"
 import localFont from "next/font/local"
-import Head from "next/head"
 
-import "../shared/styles/globals.css"
+import "@/shared/styles/globals.css"
 
 import Provider from "@/app/providers/app"
+import { Toaster } from "@/shared/components/atoms/sonner"
 import { Footer } from "@/shared/components/organisms/Footer"
 import { Header } from "@/shared/components/organisms/header"
 import { cn } from "@/shared/utils/cn"
-
-import { Toaster } from "../shared/components/atoms/sonner"
 
 const geistSans = localFont({
 	src: "./fonts/GeistVF.woff",
@@ -25,7 +23,10 @@ const geistMono = localFont({
 export const metadata: Metadata = {
 	title: "Rai Sync",
 	description:
-		"Este é o site oficial da nossa comunidade, criado para promover o aprendizado colaborativo, troca de conhecimentos e solução de dúvidas em um ambiente amigável e acessível. Nosso objetivo é construir um espaço onde todos possam aprender juntos, compartilhar experiências e crescer como comunidade."
+		"Este é o site oficial da nossa comunidade, criado para promover o aprendizado colaborativo, troca de conhecimentos e solução de dúvidas em um ambiente amigável e acessível. Nosso objetivo é construir um espaço onde todos possam aprender juntos, compartilhar experiências e crescer como comunidade.",
+	icons: {
+		icon: "/favicon.svg"
+	}
 }
 
 export default function RootLayout({
@@ -35,12 +36,9 @@ export default function RootLayout({
 }>) {
 	return (
 		<html lang="pt-br">
-			<Head>
-				<link rel="svg" type="image/svg+xml" href="/favicon.svg" />
-			</Head>
 			<body
 				className={cn(
-					"flex flex-col bg-content-shape-primary antialiased text-content-primary",
+					"flex flex-col bg-content-shape-primary text-content-primary antialiased",
 					geistSans.variable,
 					geistMono.variable
 				)}>


### PR DESCRIPTION
## Descrição

Este PR resolve o aviso sobre o uso de `next/head` dentro do diretório `app` migrando para a `API de Metadata` do Next.js. A mudança é necessária para garantir a conformidade com as melhores práticas e evitar possíveis problemas futuros e garantir que os benefícios de `SEO` do Next.js seja aplicado corretamente.

## Mudanças Realizadas

1. Removido o uso de `next/head`.
2. Utilizada a `API de Metadata` para definir o `icon`/`favicon` da pagina.
3. Correção das importações para seguir o padrão geral do projeto.

## Referências

- [Next.js `Metadata API` Documentation](https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#step-3-migrating-nexthead)